### PR TITLE
make installing simple 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ COPYRIGHT:
 In case of using your screwdriver.cd cluster
 - Install sdctl
 ```
-$ go install github.com/tk3fftk/sdctl
-$ mv $GOPATH/bin/sdctl.git $GOPATH/bin/sdctl
+$ go get github.com/tk3fftk/sdctl
 ```
 - Get screwdriver user token from https://<your_screwdrivercd>/user-settings
 - Set configurations


### PR DESCRIPTION
```
$ which sdctl
sdctl not found

$ go get github.com/tk3fftk/sdctl
$ sdctl -h
NAME:
   sdctl - Screwdriver.cd API wrapper

USAGE:
   validate yamls, start build locally
<snip>
```