### PR TITLE
fix handling for validating & tiny refactor

### DIFF
--- a/pkg/sdapi/sdapi.go
+++ b/pkg/sdapi/sdapi.go
@@ -114,7 +114,7 @@ func (sd *SDAPI) GetJWT() (string, error) {
 		return "", err
 	}
 	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("status code should be %d, but actual is%d", http.StatusOK, res.StatusCode)
+		return "", fmt.Errorf("status code should be %d, but actual is %d", http.StatusOK, res.StatusCode)
 	}
 	defer res.Body.Close()
 
@@ -141,7 +141,7 @@ func (sd *SDAPI) PostEvent(pipelineID string, startFrom string, retried bool) er
 	}
 	if res.StatusCode != http.StatusCreated { // 201 is expected as a result of POST /events
 		if retried {
-			return fmt.Errorf("status code should be %d, but actual is%d", http.StatusCreated, res.StatusCode)
+			return fmt.Errorf("status code should be %d, but actual is %d", http.StatusCreated, res.StatusCode)
 		}
 		sd.sdctx.SDJWT, err = sd.GetJWT()
 		if err != nil {
@@ -164,7 +164,7 @@ func (sd *SDAPI) Validator(yaml string, retried bool) error {
 	}
 	if res.StatusCode != http.StatusOK {
 		if retried {
-			return fmt.Errorf("status code should be %d, but actual is%d", http.StatusOK, res.StatusCode)
+			return fmt.Errorf("status code should be %d, but actual is %d", http.StatusOK, res.StatusCode)
 		}
 		sd.sdctx.SDJWT, err = sd.GetJWT()
 		if err != nil {
@@ -198,7 +198,7 @@ func (sd *SDAPI) ValidatorTemplate(yaml string, retried bool) error {
 	}
 	if res.StatusCode != http.StatusOK {
 		if retried {
-			return fmt.Errorf("status code should be %d, but actual is%d", http.StatusOK, res.StatusCode)
+			return fmt.Errorf("status code should be %d, but actual is %d", http.StatusOK, res.StatusCode)
 		}
 		sd.sdctx.SDJWT, err = sd.GetJWT()
 		if err != nil {

--- a/pkg/sdapi/sdapi.go
+++ b/pkg/sdapi/sdapi.go
@@ -93,11 +93,11 @@ func (sd *SDAPI) request(ctx context.Context, method, path string, body io.Reade
 	}
 
 	switch method {
-	case "GET":
+	case http.MethodGet:
 		{
 			req.Header.Add("Accept", "application/json")
 		}
-	case "POST":
+	case http.MethodPost:
 		{
 			req.Header.Add("Content-Type", "application/json")
 			req.Header.Add("Authorization", "Bearer "+sd.sdctx.SDJWT)
@@ -117,7 +117,7 @@ func (sd *SDAPI) request(ctx context.Context, method, path string, body io.Reade
 
 func (sd *SDAPI) GetJWT() (string, error) {
 	path := "/v4/auth/token?api_token=" + sd.sdctx.UserToken
-	res, err := sd.request(context.TODO(), "GET", path, nil)
+	res, err := sd.request(context.TODO(), http.MethodGet, path, nil)
 	if err != nil {
 		return "", err
 	}
@@ -140,8 +140,8 @@ func (sd *SDAPI) PostEvent(pipelineID string, startFrom string, retried bool) er
 		return err
 	}
 
-	res, err := sd.request(context.TODO(), "POST", path, bytes.NewBuffer([]byte(jsonBody)))
-	if res.StatusCode != 201 { // 201 is expected as a result of POST /events
+	res, err := sd.request(context.TODO(), http.MethodPost, path, bytes.NewBuffer([]byte(jsonBody)))
+	if res.StatusCode != http.StatusCreated { // 201 is expected as a result of POST /events
 		if retried {
 			return err
 		}
@@ -160,8 +160,8 @@ func (sd *SDAPI) Validator(yaml string, retried bool) error {
 	path := "/v4/validator"
 	body := `{"yaml":` + yaml + `}`
 
-	res, err := sd.request(context.TODO(), "POST", path, bytes.NewBuffer([]byte(body)))
-	if res.StatusCode != 200 {
+	res, err := sd.request(context.TODO(), http.MethodPost, path, bytes.NewBuffer([]byte(body)))
+	if res.StatusCode != http.StatusOK {
 		if retried {
 			return err
 		}
@@ -191,8 +191,8 @@ func (sd *SDAPI) ValidatorTemplate(yaml string, retried bool) error {
 	path := "/v4/validator/template"
 	body := `{"yaml":` + yaml + `}`
 
-	res, err := sd.request(context.TODO(), "POST", path, bytes.NewBuffer([]byte(body)))
-	if res.StatusCode != 200 {
+	res, err := sd.request(context.TODO(), http.MethodPost, path, bytes.NewBuffer([]byte(body)))
+	if res.StatusCode != http.StatusOK {
 		if retried {
 			return err
 		}
@@ -260,7 +260,7 @@ func (sd *SDAPI) GetPipelinePageFromBuildID(buildID string) error {
 
 func (sd *SDAPI) getBuilds(buildID string) (*buildResponse, error) {
 	path := "/v4/builds/" + buildID + "?token=" + sd.sdctx.SDJWT
-	res, err := sd.request(context.TODO(), "GET", path, nil)
+	res, err := sd.request(context.TODO(), http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func (sd *SDAPI) getBuilds(buildID string) (*buildResponse, error) {
 
 func (sd *SDAPI) getEvents(eventID int) (*eventResponse, error) {
 	path := "/v4/events/" + strconv.Itoa(eventID) + "?token=" + sd.sdctx.SDJWT
-	res, err := sd.request(context.TODO(), "GET", path, nil)
+	res, err := sd.request(context.TODO(), http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
An error occurred.
```
$ sdctl validate
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x12c29f5]

goroutine 1 [running]:
github.com/tk3fftk/sdctl/pkg/sdapi.(*SDAPI).Validator(0xc0001260c0, 0xc00015e6c0, 0x233, 0x200, 0x0, 0x0)
        /Users/cappyzawa/ghq/src/github.com/tk3fftk/sdctl/pkg/sdapi/sdapi.go:164 +0x195
main.main.func13(0xc00015c160, 0x0, 0xc00015c160)
        /Users/cappyzawa/ghq/src/github.com/tk3fftk/sdctl/sdctl.go:226 +0x97
gopkg.in/urfave/cli%2ev1.HandleAction(0x1349ce0, 0xc000136190, 0xc00015c160, 0xc0000c2100, 0x0)
        /Users/cappyzawa/ghq/src/gopkg.in/urfave/cli.v1/app.go:490 +0xc8
gopkg.in/urfave/cli%2ev1.Command.Run(0x13baba2, 0x8, 0x0, 0x0, 0xc0001361e0, 0x1, 0x1, 0x13cae9b, 0x3b, 0x0, ...)
        /Users/cappyzawa/ghq/src/gopkg.in/urfave/cli.v1/command.go:210 +0x996
gopkg.in/urfave/cli%2ev1.(*App).Run(0xc00014a000, 0xc0000a4040, 0x2, 0x2, 0x0, 0x0)
        /Users/cappyzawa/ghq/src/gopkg.in/urfave/cli.v1/app.go:255 +0x6af
main.main()
        /Users/cappyzawa/ghq/src/github.com/tk3fftk/sdctl/sdctl.go:254 +0xd87
```

The cause was that my PC's DNS was broken, but I fixed it so as not to cause panic.

I arranged the code a little bit.