### PR TITLE
enable to output validator result

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,5 @@ module github.com/tk3fftk/sdctl
 require (
 	github.com/google/go-cmp v0.2.0
 	gopkg.in/urfave/cli.v1 v1.20.0
-	gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/pkg/sdapi/sdapi_test.go
+++ b/pkg/sdapi/sdapi_test.go
@@ -224,12 +224,22 @@ func TestPostEvent(t *testing.T) {
 func TestValidator(t *testing.T) {
 	cases := map[string]struct {
 		expectedHttpResult     bool
+		output                 bool
 		expectedResponse       string
 		expectedRetry          bool
 		expectedRetryResponse  string
 		expectedValidateResult bool
 	}{
 		"POST validate successfully": {
+			true,
+			false,
+			"testdata/validate.json",
+			false,
+			"",
+			true,
+		},
+		"POST validate successfully wich output": {
+			true,
 			true,
 			"testdata/validate.json",
 			false,
@@ -238,12 +248,14 @@ func TestValidator(t *testing.T) {
 		},
 		"Retry successfully after authorization": {
 			true,
+			false,
 			mockSDUnauthorizedResponse,
 			true,
 			"testdata/validate.json",
 			true,
 		},
 		"Failure with bad request": {
+			false,
 			false,
 			mockSDBadRequestResponse,
 			false,
@@ -252,12 +264,14 @@ func TestValidator(t *testing.T) {
 		},
 		"Failure with invalid yaml": {
 			true,
+			false,
 			"testdata/config_parse_error.json",
 			false,
 			"",
 			false,
 		},
 		"Failure with bad request after retrying": {
+			false,
 			false,
 			mockSDUnauthorizedResponse,
 			true,
@@ -307,7 +321,7 @@ func TestValidator(t *testing.T) {
 				t.Fatal("should not cause error")
 			}
 
-			err = sdapi.Validator(mockYaml, false)
+			err = sdapi.Validator(mockYaml, false, v.output)
 			switch v.expectedValidateResult {
 			case true:
 				if err != nil {

--- a/sdctl.go
+++ b/sdctl.go
@@ -212,18 +212,23 @@ func main() {
 			Name:    "validate",
 			Aliases: []string{"v"},
 			Usage:   "validate your screwdriver.yaml, default to screwdriver.yaml",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "file, f",
+					Value: "screwdriver.yaml",
+					Usage: "specify pipeline file",
+				},
+				cli.BoolFlag{
+					Name:  "output",
+					Usage: "print velidator result",
+				},
+			},
 			Action: func(c *cli.Context) error {
-				var f string
-				if len(c.Args()) == 0 {
-					f = "screwdriver.yaml"
-				} else {
-					f = c.Args().Get(0)
-				}
-				yaml, err := readYaml(f)
+				yaml, err := readYaml(c.String("file"))
 				if err != nil {
 					failureExit(err)
 				}
-				if err := api.Validator(yaml, false); err != nil {
+				if err := api.Validator(yaml, false, c.Bool("output")); err != nil {
 					failureExit(err)
 				}
 


### PR DESCRIPTION
fix #17 

I tested this command file as follows.
`test.yaml`
```yaml
jobs:
    main:
        requires: [~pr, ~commit]
        template: nodejs/test@latest
```

```
$ go run sdctl.go v -f test.yaml --output
annotations: {}
jobs:
  main:
  - annotations: {}
    commands:
    - command: |
        NPM_VERSION=`npm -v | awk -F '.' '{printf "%2d%02d", $1,$2}'`
        if [ -e yarn.lock ]
        then
          npm install -g yarn
          yarn install
        else
          if [ "$NPM_VERSION" -ge "507" ] && [ -e package-lock.json -o -e npm-shrinkwrap.json ]
          then
            npm ci
          else
            npm install
          fi
        fi
      name: install
    - command: |
        if [ "$NPM_VERSION" -ge "600" ]; then
          if [ -e yarn.lock ]
          then
            yarn audit && :
            if [ "$?" -ne "0" ] && [ "$NODEJS_STRICT_AUDIT" != "false" ]; then
              echo yarn audit exited with errors
              false
            fi
          else
            npm audit && :
            if [ "$?" -ne "0" ] && [ "$NODEJS_STRICT_AUDIT" != "false" ]; then
              echo npm audit exited with errors
              false
            fi
          fi
        else
          echo Skipping npm audit due to old npm version
        fi
      name: audit
    - command: npm run-script lint --if-present
      name: lint
    - command: npm run-script ${NODE_BUILD_SCRIPT}
      name: build
    - command: npm test
      name: test
    environment:
      NODE_BUILD_SCRIPT: --if-present build
      NODEJS_IMAGE_TAG: "8"
      NODEJS_STRICT_AUDIT: "false"
      SD_TEMPLATE_FULLNAME: nodejs/test
      SD_TEMPLATE_NAME: test
      SD_TEMPLATE_NAMESPACE: nodejs
      SD_TEMPLATE_VERSION: 0.0.15
   <snip>
    requires:
    - ~pr
    - ~commit
    secrets: []
    settings: {}
workflowGraph:
  edges:
  - dest: main
    src: ~pr
  - dest: main
    src: ~commit
  nodes:
  - name: ~pr
  - name: ~commit
  - name: main

```