### PR TITLE
Add `SilenceUsage` and `SilentErorrs` to each command

### DIFF
--- a/command/banner_get.go
+++ b/command/banner_get.go
@@ -22,6 +22,7 @@ func NewCmdBannerGet(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/banner_get.go
+++ b/command/banner_get.go
@@ -22,7 +22,7 @@ func NewCmdBannerGet(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/banner_get.go
+++ b/command/banner_get.go
@@ -23,6 +23,7 @@ func NewCmdBannerGet(api sdapi.SDAPI) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/banner_update.go
+++ b/command/banner_update.go
@@ -29,6 +29,7 @@ func NewCmdBannerUpdate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 
 	cmd.Flags().StringVarP(&id, "id", "i", "", "specify banner ID when update or delete")

--- a/command/banner_update.go
+++ b/command/banner_update.go
@@ -30,6 +30,7 @@ func NewCmdBannerUpdate(api sdapi.SDAPI) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 
 	cmd.Flags().StringVarP(&id, "id", "i", "", "specify banner ID when update or delete")

--- a/command/banner_update.go
+++ b/command/banner_update.go
@@ -29,7 +29,7 @@ func NewCmdBannerUpdate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 

--- a/command/clear.go
+++ b/command/clear.go
@@ -20,6 +20,7 @@ func NewCmdClear(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/clear.go
+++ b/command/clear.go
@@ -20,7 +20,7 @@ func NewCmdClear(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/clear.go
+++ b/command/clear.go
@@ -21,6 +21,7 @@ func NewCmdClear(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/cmd.go
+++ b/command/cmd.go
@@ -16,6 +16,7 @@ func NewCmd(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Command {
 			cmd.Help()
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 
 	cmd.AddCommand(

--- a/command/cmd.go
+++ b/command/cmd.go
@@ -15,7 +15,7 @@ func NewCmd(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 

--- a/command/cmd.go
+++ b/command/cmd.go
@@ -15,6 +15,7 @@ func NewCmd(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},
+		SilenceUsage: true,
 	}
 
 	cmd.AddCommand(

--- a/command/context_current.go
+++ b/command/context_current.go
@@ -19,6 +19,7 @@ func NewCmdContextCurrent(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/context_current.go
+++ b/command/context_current.go
@@ -19,7 +19,7 @@ func NewCmdContextCurrent(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/context_current.go
+++ b/command/context_current.go
@@ -20,6 +20,7 @@ func NewCmdContextCurrent(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/context_list.go
+++ b/command/context_list.go
@@ -20,6 +20,7 @@ func NewCmdContextList(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/context_list.go
+++ b/command/context_list.go
@@ -20,7 +20,7 @@ func NewCmdContextList(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/context_list.go
+++ b/command/context_list.go
@@ -21,6 +21,7 @@ func NewCmdContextList(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/context_set.go
+++ b/command/context_set.go
@@ -20,6 +20,7 @@ func NewCmdContextSet(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/context_set.go
+++ b/command/context_set.go
@@ -21,6 +21,7 @@ func NewCmdContextSet(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/context_set.go
+++ b/command/context_set.go
@@ -20,7 +20,7 @@ func NewCmdContextSet(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/get_api.go
+++ b/command/get_api.go
@@ -20,6 +20,7 @@ func NewCmdGetAPI(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/get_api.go
+++ b/command/get_api.go
@@ -19,6 +19,7 @@ func NewCmdGetAPI(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/get_api.go
+++ b/command/get_api.go
@@ -19,7 +19,7 @@ func NewCmdGetAPI(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/get_build_pages.go
+++ b/command/get_build_pages.go
@@ -20,7 +20,7 @@ func NewCmdGetBuildPages(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/get_build_pages.go
+++ b/command/get_build_pages.go
@@ -21,6 +21,7 @@ func NewCmdGetBuildPages(api sdapi.SDAPI) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/get_build_pages.go
+++ b/command/get_build_pages.go
@@ -20,6 +20,7 @@ func NewCmdGetBuildPages(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/get_jwt.go
+++ b/command/get_jwt.go
@@ -19,6 +19,7 @@ func NewCmdGetJWT(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/get_jwt.go
+++ b/command/get_jwt.go
@@ -20,6 +20,7 @@ func NewCmdGetJWT(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/get_jwt.go
+++ b/command/get_jwt.go
@@ -19,7 +19,7 @@ func NewCmdGetJWT(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/get_token.go
+++ b/command/get_token.go
@@ -19,7 +19,7 @@ func NewCmdGetToken(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/get_token.go
+++ b/command/get_token.go
@@ -19,6 +19,7 @@ func NewCmdGetToken(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/get_token.go
+++ b/command/get_token.go
@@ -20,6 +20,7 @@ func NewCmdGetToken(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/set_api.go
+++ b/command/set_api.go
@@ -20,6 +20,7 @@ func NewCmdSetAPI(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/set_api.go
+++ b/command/set_api.go
@@ -20,7 +20,7 @@ func NewCmdSetAPI(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/set_api.go
+++ b/command/set_api.go
@@ -21,6 +21,7 @@ func NewCmdSetAPI(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/set_jwt.go
+++ b/command/set_jwt.go
@@ -23,7 +23,7 @@ func NewCmdSetJWT(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Comm
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/set_jwt.go
+++ b/command/set_jwt.go
@@ -24,6 +24,7 @@ func NewCmdSetJWT(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Comm
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/set_jwt.go
+++ b/command/set_jwt.go
@@ -23,6 +23,7 @@ func NewCmdSetJWT(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Comm
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/set_token.go
+++ b/command/set_token.go
@@ -21,6 +21,7 @@ func NewCmdSetToken(config sdctl_context.SdctlConfig) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/set_token.go
+++ b/command/set_token.go
@@ -20,7 +20,7 @@ func NewCmdSetToken(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd

--- a/command/set_token.go
+++ b/command/set_token.go
@@ -20,6 +20,7 @@ func NewCmdSetToken(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	return cmd
 }

--- a/command/validate.go
+++ b/command/validate.go
@@ -24,6 +24,7 @@ func NewCmdValidate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	cmd.Flags().StringVarP(&pipelineFilePATH, "file", "f", "screwdriver.yaml", "specify pipeline file path")
 	cmd.Flags().BoolVarP(&validatedOutput, "output", "o", false, "print velidator result")

--- a/command/validate.go
+++ b/command/validate.go
@@ -25,6 +25,7 @@ func NewCmdValidate(api sdapi.SDAPI) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	cmd.Flags().StringVarP(&pipelineFilePATH, "file", "f", "screwdriver.yaml", "specify pipeline file path")
 	cmd.Flags().BoolVarP(&validatedOutput, "output", "o", false, "print velidator result")

--- a/command/validate.go
+++ b/command/validate.go
@@ -24,7 +24,7 @@ func NewCmdValidate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	cmd.Flags().StringVarP(&pipelineFilePATH, "file", "f", "screwdriver.yaml", "specify pipeline file path")

--- a/command/validate_template.go
+++ b/command/validate_template.go
@@ -23,7 +23,7 @@ func NewCmdValidateTemplate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	cmd.Flags().StringVarP(&templateFilePATH, "file", "f", "sd-template.yaml", "specify template file path")

--- a/command/validate_template.go
+++ b/command/validate_template.go
@@ -24,6 +24,7 @@ func NewCmdValidateTemplate(api sdapi.SDAPI) *cobra.Command {
 			return o.Run(cmd, args)
 		},
 		SilenceUsage: true,
+		SilenceErrors: true,
 	}
 	cmd.Flags().StringVarP(&templateFilePATH, "file", "f", "sd-template.yaml", "specify template file path")
 	return cmd

--- a/command/validate_template.go
+++ b/command/validate_template.go
@@ -23,6 +23,7 @@ func NewCmdValidateTemplate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
+		SilenceUsage: true,
 	}
 	cmd.Flags().StringVarP(&templateFilePATH, "file", "f", "sd-template.yaml", "specify template file path")
 	return cmd


### PR DESCRIPTION
I tried to use `sdctl banner set ...`.
```
$ sdctl banner set -m "test Message"
Error: status code should be 201 or 200, but actual is 403
Usage:
  sdctl banner set [flags]

Flags:
  -a, --active string   banner status flag (true, false) (default "true")
  -d, --delete          flag for delete banner (required with id)
  -h, --help            help for set
  -i, --id string       specify banner ID when update or delete
  -m, --msg string      banner message body
  -t, --type string     banner type (info, warn) (default "info")

[ERROR] status code should be 201 or 200, but actual is 403
```
403 is correct because I'm not an admin user.

I'm worried that help is displayed even though the usage of the command is correct.

## Changes
I added `SilenceUsage: true` to each command.

```
$go run sdctl.go banner set -m "test Message"
[ERROR] status code should be 201 or 200, but actual is 403
exit status 1

$ go run sdctl.go banner set -h
update a banner with POST, PUT, DELETE method. specify banner ID when using PUT or DELETE method

Usage:
  sdctl banner set [flags]

Flags:
  -a, --active string   banner status flag (true, false) (default "true")
  -d, --delete          flag for delete banner (required with id)
  -h, --help            help for set
  -i, --id string       specify banner ID when update or delete
  -m, --msg string      banner message body
  -t, --type string     banner type (info, warn) (default "info")
```

Don't show help when an error occurs in command and disable to print error by cobra.