### PR TITLE
feat(19): add goreleaser configurations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+dist/
 
 # Test binary, build with `go test -c`
 *.test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,41 @@
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # you may remove this if you don't use vgo
+    - go mod download
+    # you may remove this if you don't need go generate
+    #- go generate ./...
+builds:
+- env:
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+  goos:
+  - windows
+  - darwin
+  - linux
+  goarch:
+  - amd64
+  #- 386
+  ldflags:
+  - -s -w
+    -X github.com/tk3fftk/sdctl/command.version={{.Version}}
+    -X github.com/tk3fftk/sdctl/command.commit={{.Commit}}
+    -X github.com/tk3fftk/sdctl/command.date={{.Date}}
+    -X github.com/tk3fftk/sdctl/command.builtBy=goreleaser
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/command/cmd.go
+++ b/command/cmd.go
@@ -1,9 +1,18 @@
 package command
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/tk3fftk/sdctl/pkg/sdapi"
 	"github.com/tk3fftk/sdctl/pkg/sdctl_context"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "unknown"
 )
 
 func NewCmd(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Command {
@@ -11,7 +20,7 @@ func NewCmd(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Command {
 		Use:     "sdctl",
 		Short:   "Screwdriver.cd API wrapper",
 		Long:    "validate yamls, handle banners, start build from CLI",
-		Version: "0.2.0",
+		Version: fmt.Sprintf("%v, commit %v, built at %v", version, commit, date),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},


### PR DESCRIPTION
## Objectives

This PR adds goreleaser's configuration file and injects version information by the latest git tag.

- Version injection sample.
```bash
# Snapshot build
$ goreleaser --snapshot --skip-publish --rm-dist
...
$ ./dist/sdctl_linux_amd64/sdctl --version
sdctl version v0.0.0-next, commit 927be9599d34eb494feb55966ed253c679bec2bd, built at 2019-07-21T05:20:47Z

# Production release
$ export GITHUB_TOKEN=**************************
$ git tag -a v0.2.1 -m 'release annotations.'
$ git push --tags
$ goreleaser --rm-dist
...
# download a binary from the release page.
$ ./sdctl --versioin
sdctl version 0.2.1, commit <commit_sha> built at <datetime>
```

## References
- https://github.com/tk3fftk/sdctl/issues/19