### PR TITLE
remove silence setting from subcommands

### DIFF
--- a/command/banner_get.go
+++ b/command/banner_get.go
@@ -22,8 +22,6 @@ func NewCmdBannerGet(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/banner_update.go
+++ b/command/banner_update.go
@@ -29,8 +29,6 @@ func NewCmdBannerUpdate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 
 	cmd.Flags().StringVarP(&id, "id", "i", "", "specify banner ID when update or delete")

--- a/command/clear.go
+++ b/command/clear.go
@@ -20,8 +20,6 @@ func NewCmdClear(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/context_current.go
+++ b/command/context_current.go
@@ -19,8 +19,6 @@ func NewCmdContextCurrent(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/context_list.go
+++ b/command/context_list.go
@@ -20,8 +20,6 @@ func NewCmdContextList(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/context_set.go
+++ b/command/context_set.go
@@ -20,8 +20,6 @@ func NewCmdContextSet(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/get_api.go
+++ b/command/get_api.go
@@ -19,8 +19,6 @@ func NewCmdGetAPI(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/get_build_pages.go
+++ b/command/get_build_pages.go
@@ -20,8 +20,6 @@ func NewCmdGetBuildPages(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/get_jwt.go
+++ b/command/get_jwt.go
@@ -19,8 +19,6 @@ func NewCmdGetJWT(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/get_token.go
+++ b/command/get_token.go
@@ -19,8 +19,6 @@ func NewCmdGetToken(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/set_api.go
+++ b/command/set_api.go
@@ -20,8 +20,6 @@ func NewCmdSetAPI(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/set_jwt.go
+++ b/command/set_jwt.go
@@ -23,8 +23,6 @@ func NewCmdSetJWT(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Comm
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/set_token.go
+++ b/command/set_token.go
@@ -20,8 +20,6 @@ func NewCmdSetToken(config sdctl_context.SdctlConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	return cmd
 }

--- a/command/validate.go
+++ b/command/validate.go
@@ -24,8 +24,6 @@ func NewCmdValidate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	cmd.Flags().StringVarP(&pipelineFilePATH, "file", "f", "screwdriver.yaml", "specify pipeline file path")
 	cmd.Flags().BoolVarP(&validatedOutput, "output", "o", false, "print velidator result")

--- a/command/validate_template.go
+++ b/command/validate_template.go
@@ -23,8 +23,6 @@ func NewCmdValidateTemplate(api sdapi.SDAPI) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.Run(cmd, args)
 		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
 	}
 	cmd.Flags().StringVarP(&templateFilePATH, "file", "f", "sd-template.yaml", "specify template file path")
 	return cmd


### PR DESCRIPTION
I added silence settings in #24.

There is no problem, but I will remove it from the subcommand to make it simpler.

There is no change in behavior.
```
$ go run sdctl.go banner set -m "foo"
[ERROR] status code should be 201 or 200, but actual is 403
exit status 1
```