### PR TITLE
Add Secret Command(set only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,9 @@ Successfully DELETE a banner ID 28
 $ sdctl banner get
 ID	IsActive	Message
 ```
+
+- write a secret
+```bash
+$ sdctl secret set -p 1111 -k FOO -v bar 
+setting secret FOO is succuseed!
+```

--- a/command/cmd.go
+++ b/command/cmd.go
@@ -36,6 +36,7 @@ func NewCmd(config sdctl_context.SdctlConfig, api sdapi.SDAPI) *cobra.Command {
 		NewCmdGet(config, api),
 		NewCmdSet(config, api),
 		NewCmdValidate(api),
-		NewCmdValidateTemplate(api))
+		NewCmdValidateTemplate(api),
+		NewCmdSecret(api))
 	return cmd
 }

--- a/command/secret.go
+++ b/command/secret.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tk3fftk/sdctl/pkg/sdapi"
+)
+
+func NewCmdSecret(api sdapi.SDAPI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secret",
+		Short: "handle screwdriver secrets (write only)",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+		Aliases: []string{"sec"},
+	}
+
+	cmd.AddCommand(
+		NewCmdSecretSet(api),
+	)
+	return cmd
+}

--- a/command/secret_set.go
+++ b/command/secret_set.go
@@ -1,0 +1,58 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tk3fftk/sdctl/pkg/sdapi"
+)
+
+type SecretSetOption struct {
+	API         sdapi.SDAPI
+	PipelineID  string
+	SecretKey   string
+	SecretValue string
+	AllowInPR   bool
+}
+
+func NewCmdSecretSet(api sdapi.SDAPI) *cobra.Command {
+	o := &SecretSetOption{
+		API: api,
+	}
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "set secret to pipeline",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Run(cmd, args)
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.PipelineID, "pipeline", "p", "", "specify pipeline id")
+	_ = cmd.MarkFlagRequired("pipeline")
+	cmd.Flags().StringVarP(&o.SecretKey, "key", "k", "", "SECRET_KEY")
+	_ = cmd.MarkFlagRequired("key")
+	cmd.Flags().StringVarP(&o.SecretValue, "value", "v", "", "SECRET_VALUE")
+	_ = cmd.MarkFlagRequired("value")
+	cmd.Flags().BoolVarP(&o.AllowInPR, "allow-in-pr", "", false, "ALLOW_IN_PR")
+
+	return cmd
+}
+
+func (o *SecretSetOption) Run(cmd *cobra.Command, args []string) error {
+	pipelineIDNum, err := strconv.Atoi(o.PipelineID)
+	if err != nil {
+		return fmt.Errorf("failed to convert %s to int: %v", o.PipelineID, err)
+	}
+
+	// Screwdriver allow only "/^[A-Z_][A-Z0-9_]*$/]" as secret key
+	uppperKey := strings.ToUpper(o.SecretKey)
+	if err := o.API.UpdateSecret(pipelineIDNum, uppperKey, o.SecretValue, o.AllowInPR); err != nil {
+		return fmt.Errorf("failed to set secret: %v", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "setting secret %s is succeed!\n", uppperKey)
+	return nil
+}

--- a/command/secret_set.go
+++ b/command/secret_set.go
@@ -49,7 +49,7 @@ func (o *SecretSetOption) Run(cmd *cobra.Command, args []string) error {
 
 	// Screwdriver allow only "/^[A-Z_][A-Z0-9_]*$/]" as secret key
 	uppperKey := strings.ToUpper(o.SecretKey)
-	if err := o.API.UpdateSecret(pipelineIDNum, uppperKey, o.SecretValue, o.AllowInPR); err != nil {
+	if err := o.API.SetSecret(pipelineIDNum, uppperKey, o.SecretValue, o.AllowInPR); err != nil {
 		return fmt.Errorf("failed to set secret: %v", err)
 	}
 

--- a/pkg/sdapi/sdapi.go
+++ b/pkg/sdapi/sdapi.go
@@ -369,3 +369,97 @@ func (sd *SDAPI) getEvents(eventID int) (*eventResponse, error) {
 
 	return eventResponse, err
 }
+
+type Secret struct {
+	ID         int    `json:"id"`
+	PipelineID int    `json:"pipelineId"`
+	Name       string `json:"name"`
+	AllowInPR  bool   `json:"allowInPR"`
+}
+
+func (sd *SDAPI) UpdateSecret(pipelineID int, key, value string, allowInPR bool) error {
+
+	secrets, err := sd.getPipelineSecrets(pipelineID)
+	if err != nil {
+		return err
+	}
+
+	duplicatedKeyID, exist := sd.checkKey(secrets, key)
+
+	if !exist {
+		return sd.createSecret(pipelineID, key, value, allowInPR)
+	}
+
+	return sd.updateSecret(duplicatedKeyID, value, allowInPR)
+}
+
+func (sd *SDAPI) getPipelineSecrets(pipelineID int) ([]Secret, error) {
+	path := fmt.Sprintf("/v4/pipelines/%d/secrets?token=%s", pipelineID, sd.sdctx.SDJWT)
+	res, err := sd.request(context.TODO(), http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s status code is not %d: %d", path, http.StatusOK, res.StatusCode)
+	}
+	var secrets []Secret
+	if err := json.NewDecoder(res.Body).Decode(&secrets); err != nil {
+		return nil, err
+	}
+
+	return secrets, nil
+}
+
+func (sd *SDAPI) checkKey(secrets []Secret, key string) (int, bool) {
+	for _, s := range secrets {
+		if s.Name == key {
+			return s.ID, true
+		}
+	}
+	return 0, false
+}
+
+func (sd *SDAPI) createSecret(pipelineID int, key, value string, allowInPR bool) error {
+	path := "/v4/secrets"
+	body := make(map[string]interface{})
+	body["pipelineId"] = pipelineID
+	body["name"] = key
+	body["value"] = value
+	body["allowInPR"] = allowInPR
+	bodyJSON, err := json.Marshal(&body)
+	if err != nil {
+		return err
+	}
+	res, err := sd.request(context.TODO(), http.MethodPost, path, bytes.NewBuffer(bodyJSON))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusCreated {
+		return fmt.Errorf("POST %s status code is not %d: %d", path, http.StatusCreated, res.StatusCode)
+	}
+	return nil
+}
+
+func (sd *SDAPI) updateSecret(secretID int, value string, allowInPR bool) error {
+	path := fmt.Sprintf("/v4/secrets/%d", secretID)
+	body := make(map[string]interface{})
+	body["value"] = value
+	body["allowInPR"] = allowInPR
+	bodyJSON, err := json.Marshal(&body)
+	if err != nil {
+		return err
+	}
+	res, err := sd.request(context.TODO(), http.MethodPut, path, bytes.NewBuffer(bodyJSON))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("PUT %s status code is not %d: %d", path, http.StatusOK, res.StatusCode)
+	}
+	return nil
+}

--- a/pkg/sdapi/sdapi.go
+++ b/pkg/sdapi/sdapi.go
@@ -377,7 +377,7 @@ type Secret struct {
 	AllowInPR  bool   `json:"allowInPR"`
 }
 
-func (sd *SDAPI) UpdateSecret(pipelineID int, key, value string, allowInPR bool) error {
+func (sd *SDAPI) SetSecret(pipelineID int, key, value string, allowInPR bool) error {
 
 	secrets, err := sd.getPipelineSecrets(pipelineID)
 	if err != nil {

--- a/pkg/sdapi/sdapi_test.go
+++ b/pkg/sdapi/sdapi_test.go
@@ -614,7 +614,7 @@ func TestValidatorTemplate(t *testing.T) {
 	}
 }
 
-func TestgetPipelineSecrets(t *testing.T) {
+func TestGetPipelineSecrets(t *testing.T) {
 	pipelineID := 1111
 
 	cases := map[string]struct {
@@ -679,7 +679,7 @@ func TestgetPipelineSecrets(t *testing.T) {
 	}
 }
 
-func TestcreateSecret(t *testing.T) {
+func TestCreateSecret(t *testing.T) {
 	pipelineID := 1111
 	key := "secretKey"
 	value := "secretValue"
@@ -725,7 +725,7 @@ func TestcreateSecret(t *testing.T) {
 	}
 }
 
-func TestupdateSecret(t *testing.T) {
+func TestUpdateSecret(t *testing.T) {
 	secretID := 11
 	value := "secretValue"
 	allowInPR := false
@@ -770,7 +770,7 @@ func TestupdateSecret(t *testing.T) {
 	}
 }
 
-func TestUpdateSecret(t *testing.T) {
+func TestSetSecret(t *testing.T) {
 	pipelineID := 1111
 	value := "secretValue"
 	allowInPR := false
@@ -876,7 +876,7 @@ func TestUpdateSecret(t *testing.T) {
 			if err != nil {
 				t.Fatal("should not cause error")
 			}
-			actual := sdapi.UpdateSecret(pipelineID, v.key, value, allowInPR)
+			actual := sdapi.SetSecret(pipelineID, v.key, value, allowInPR)
 			if !reflect.DeepEqual(err, v.expectErr) {
 				t.Errorf("err should be %#v, but actual is %#v", v.expectErr, actual)
 			}

--- a/pkg/sdapi/sdapi_test.go
+++ b/pkg/sdapi/sdapi_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -608,6 +609,283 @@ func TestValidatorTemplate(t *testing.T) {
 				} else {
 					fmt.Printf("%v\n", err)
 				}
+			}
+		})
+	}
+}
+
+func TestgetPipelineSecrets(t *testing.T) {
+	pipelineID := 1111
+
+	cases := map[string]struct {
+		secretsStatusCode int
+		expectSecrets     []Secret
+		expectErr         error
+	}{
+		"Get secrets successfully": {
+			http.StatusOK,
+			[]Secret{
+				{
+					ID:         11,
+					PipelineID: pipelineID,
+					Name:       "name1",
+					AllowInPR:  true,
+				},
+				{
+					ID:         12,
+					PipelineID: pipelineID,
+					Name:       "name2",
+					AllowInPR:  false,
+				},
+			},
+			nil,
+		},
+		"Failed to get secrets because of invalid status code": {
+			http.StatusUnauthorized,
+			nil,
+			fmt.Errorf("GET /v4/pipelines/%d/secrets?token=invalid_jwt status code is not %d: %d", pipelineID, http.StatusOK, http.StatusUnauthorized),
+		},
+	}
+
+	for k, v := range cases {
+		k := k
+		v := v
+		t.Run(k, func(t *testing.T) {
+			muxAPI := http.NewServeMux()
+			testAPIServer := httptest.NewServer(muxAPI)
+			defer testAPIServer.Close()
+
+			path := fmt.Sprintf("/v4/pipelines/%d/secrets", pipelineID)
+
+			muxAPI.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(v.secretsStatusCode)
+				secretsJSON, _ := json.Marshal(v.expectSecrets)
+				w.Write(secretsJSON)
+			})
+
+			mockSDContext.APIURL = testAPIServer.URL
+			sdapi, err := New(mockSDContext, nil)
+			if err != nil {
+				t.Fatal("should not cause error")
+			}
+			secrets, err := sdapi.getPipelineSecrets(pipelineID)
+			if !reflect.DeepEqual(err, v.expectErr) {
+				t.Errorf("err should be %#v, but actual is %#v", v.expectErr, err)
+			}
+			if !reflect.DeepEqual(secrets, v.expectSecrets) {
+				t.Errorf("secrets should be %#v, but actual is %#v", v.expectSecrets, secrets)
+			}
+		})
+	}
+}
+
+func TestcreateSecret(t *testing.T) {
+	pipelineID := 1111
+	key := "secretKey"
+	value := "secretValue"
+	allowInPR := false
+
+	cases := map[string]struct {
+		createdStatusCode int
+		expectErr         error
+	}{
+		"Create a secret successfully": {
+			http.StatusCreated,
+			nil,
+		},
+		"Failed to create a secrets because of invalid status code": {
+			http.StatusUnauthorized,
+			fmt.Errorf("POST /v4/secrets status code is not %d: %d", http.StatusCreated, http.StatusUnauthorized),
+		},
+	}
+
+	for k, v := range cases {
+		k := k
+		v := v
+		t.Run(k, func(t *testing.T) {
+			muxAPI := http.NewServeMux()
+			testAPIServer := httptest.NewServer(muxAPI)
+			defer testAPIServer.Close()
+
+			path := "/v4/secrets"
+			muxAPI.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(v.createdStatusCode)
+			})
+
+			mockSDContext.APIURL = testAPIServer.URL
+			sdapi, err := New(mockSDContext, nil)
+			if err != nil {
+				t.Fatal("should not cause error")
+			}
+			actual := sdapi.createSecret(pipelineID, key, value, allowInPR)
+			if !reflect.DeepEqual(actual, v.expectErr) {
+				t.Errorf("err should be %#v, but actual is %#v", v.expectErr, actual)
+			}
+		})
+	}
+}
+
+func TestupdateSecret(t *testing.T) {
+	secretID := 11
+	value := "secretValue"
+	allowInPR := false
+
+	cases := map[string]struct {
+		updatedStatusCode int
+		expectErr         error
+	}{
+		"Updated a secret successfully": {
+			http.StatusOK,
+			nil,
+		},
+		"Failed to update a secret because of invalid status code": {
+			http.StatusUnauthorized,
+			fmt.Errorf("PUT /v4/secrets/%d status code is not %d: %d", secretID, http.StatusOK, http.StatusUnauthorized),
+		},
+	}
+
+	for k, v := range cases {
+		k := k
+		v := v
+		t.Run(k, func(t *testing.T) {
+			muxAPI := http.NewServeMux()
+			testAPIServer := httptest.NewServer(muxAPI)
+			defer testAPIServer.Close()
+
+			path := fmt.Sprintf("/v4/secrets/%d", secretID)
+			muxAPI.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(v.updatedStatusCode)
+			})
+
+			mockSDContext.APIURL = testAPIServer.URL
+			sdapi, err := New(mockSDContext, nil)
+			if err != nil {
+				t.Fatal("should not cause error")
+			}
+			actual := sdapi.updateSecret(secretID, value, allowInPR)
+			if !reflect.DeepEqual(actual, v.expectErr) {
+				t.Errorf("err should be %#v, but actual is %#v", v.expectErr, actual)
+			}
+		})
+	}
+}
+
+func TestUpdateSecret(t *testing.T) {
+	pipelineID := 1111
+	value := "secretValue"
+	allowInPR := false
+	cases := map[string]struct {
+		key     string
+		secrets []Secret
+
+		secretsStatusCode int
+		createdStatusCode int
+		updatedStatusCode int
+
+		createCount int
+		updateCount int
+
+		expectErr error
+	}{
+		"Create a secret successfully": {
+			"name3",
+			[]Secret{
+				{
+					ID:         11,
+					PipelineID: pipelineID,
+					Name:       "name1",
+					AllowInPR:  true,
+				},
+				{
+					ID:         12,
+					PipelineID: pipelineID,
+					Name:       "name2",
+					AllowInPR:  false,
+				},
+			},
+			http.StatusOK,
+			http.StatusCreated,
+			0,
+			1,
+			0,
+			nil,
+		},
+		"Update a secret successfully": {
+			"name1",
+			[]Secret{
+				{
+					ID:         11,
+					PipelineID: pipelineID,
+					Name:       "name1",
+					AllowInPR:  true,
+				},
+				{
+					ID:         12,
+					PipelineID: pipelineID,
+					Name:       "name2",
+					AllowInPR:  false,
+				},
+			},
+			http.StatusOK,
+			0,
+			http.StatusOK,
+			0,
+			1,
+			nil,
+		},
+	}
+
+	for k, v := range cases {
+		k := k
+		v := v
+		t.Run(k, func(t *testing.T) {
+			muxAPI := http.NewServeMux()
+			testAPIServer := httptest.NewServer(muxAPI)
+			defer testAPIServer.Close()
+
+			pipelineSecretPATH := fmt.Sprintf("/v4/pipelines/%d/secrets", pipelineID)
+
+			muxAPI.HandleFunc(pipelineSecretPATH, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(v.secretsStatusCode)
+				secretsJSON, _ := json.Marshal(v.secrets)
+				w.Write(secretsJSON)
+			})
+
+			var (
+				createCount int
+				updateCount int
+			)
+			if v.createdStatusCode != 0 {
+				createSecretPATH := "/v4/secrets"
+				muxAPI.HandleFunc(createSecretPATH, func(w http.ResponseWriter, r *http.Request) {
+					createCount++
+					w.WriteHeader(v.createdStatusCode)
+				})
+			}
+
+			if v.updatedStatusCode != 0 {
+				updateSecretPATH := fmt.Sprintf("/v4/secrets/%d", 11)
+				muxAPI.HandleFunc(updateSecretPATH, func(w http.ResponseWriter, r *http.Request) {
+					updateCount++
+					w.WriteHeader(v.updatedStatusCode)
+				})
+			}
+
+			mockSDContext.APIURL = testAPIServer.URL
+			sdapi, err := New(mockSDContext, nil)
+			if err != nil {
+				t.Fatal("should not cause error")
+			}
+			actual := sdapi.UpdateSecret(pipelineID, v.key, value, allowInPR)
+			if !reflect.DeepEqual(err, v.expectErr) {
+				t.Errorf("err should be %#v, but actual is %#v", v.expectErr, actual)
+			}
+
+			if createCount != v.createCount {
+				t.Errorf("create count should be %d, but actual is %d", v.createCount, createCount)
+			}
+			if updateCount != v.updateCount {
+				t.Errorf("update count should be %d, but actual is %d", v.updateCount, updateCount)
 			}
 		})
 	}


### PR DESCRIPTION
Added `secret` (or `sec`) commnad.

This command update specified secret.
If the pipeline doesn't have specified secret, this command request `POST /v4/secrets`.
If the pipeline has specified secret, this does `PUT /v4/secrets/<specified secret id>`.

ex
```
# create
$ go run sdctl.go secret set -p 69098 -k BAR -v "fooo"
setting secret BAR is succeed!

# update
$ go run sdctl.go secret set -p 69098 -k BAR -v "fooo"
setting secret BAR is succeed!
```