### PR TITLE
Format `get bp` and `banner get` columns

### DIFF
--- a/command/banner_get.go
+++ b/command/banner_get.go
@@ -41,8 +41,12 @@ func (o *BannerGetOption) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (o *BannerGetOption) print(banners []sdapi.BannerResponse) {
-	fmt.Fprintf(os.Stdout, "ID\tIsActive\tMessage\n")
+	o.printColumn("ID", "IsActive", "Message")
 	for _, b := range banners {
-		fmt.Fprintf(os.Stdout, "%v\t%v\t%v\n", b.ID, b.IsActive, b.Message)
+		o.printColumn(b.ID, b.IsActive, b.Message)
 	}
+}
+
+func (o *BannerGetOption) printColumn(id, isActive, msg interface{}) {
+	fmt.Fprintf(os.Stdout, "%-8v%-12v%v\n", id, isActive, msg)
 }

--- a/pkg/sdapi/sdapi.go
+++ b/pkg/sdapi/sdapi.go
@@ -329,7 +329,7 @@ func (sd *SDAPI) GetPipelinePageFromBuildID(buildID string) error {
 	wg.Add(buildIDLength)
 
 	exit := make(chan error, buildIDLength)
-	fmt.Fprintf(os.Stdout, "%-80v%-15v\n", "buildURL", "repo (job)")
+	fmt.Fprintf(os.Stdout, "%-80v%-15v\n", "BuildURL", "Repo (Job)")
 	for _, b := range buildIDList {
 		go func(b string) {
 			defer wg.Done()

--- a/pkg/sdapi/sdapi.go
+++ b/pkg/sdapi/sdapi.go
@@ -329,7 +329,7 @@ func (sd *SDAPI) GetPipelinePageFromBuildID(buildID string) error {
 	wg.Add(buildIDLength)
 
 	exit := make(chan error, buildIDLength)
-
+	fmt.Fprintf(os.Stdout, "%-80v%-15v\n", "buildURL", "repo (job)")
 	for _, b := range buildIDList {
 		go func(b string) {
 			defer wg.Done()
@@ -349,7 +349,9 @@ func (sd *SDAPI) GetPipelinePageFromBuildID(buildID string) error {
 				exit <- err
 				return
 			}
-			fmt.Println(basePipelineURL + strconv.Itoa(jr.PipelineID) + "/builds/" + b + "\t" + pr.SCMRepo.Name + "(" + jr.Name + ")")
+			buildURL := fmt.Sprintf("%s%d/builds/%s", basePipelineURL, jr.PipelineID, b)
+			repoJob := fmt.Sprintf("%s (%s)", pr.SCMRepo.Name, jr.Name)
+			fmt.Fprintf(os.Stdout, "%-80v%-15v\n", buildURL, repoJob)
 		}(b)
 	}
 


### PR DESCRIPTION
If it is `\t`, the layout may be broken depending on the character string displayed.

```bash
$ go run sdctl.go get bp "6372625"
BuildURL                                                                        Repo (Job)     
https://cd.screwdriver.xxxxxxxxxxxxxxxx/pipelines/75017/builds/6372625          cloudfoundry/go-image (get-latest-release-tag)

$ go run sdctl.go banner get 
ID      IsActive    Message
9       true        yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
3       false       zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
```